### PR TITLE
Fix tx.map type error

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20,7 +20,14 @@ app.get('/api/accounts', async (req, res) => {
         'User-Agent': 'openbanking-demo'
       }
     });
-    const data = await response.json();
+    const text = await response.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : { transactions: [] };
+    } catch (parseErr) {
+      console.error('Invalid JSON from Starling', parseErr);
+      data = { transactions: [] };
+    }
     res.json(data);
   } catch (err) {
     console.error('Error fetching accounts', err);
@@ -43,7 +50,14 @@ app.get('/api/accounts/:accountUid/transactions', async (req, res) => {
         'User-Agent': 'openbanking-demo'
       }
     });
-    const data = await response.json();
+    const text = await response.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : { transactions: [] };
+    } catch (parseErr) {
+      console.error('Invalid JSON from Starling', parseErr);
+      data = { transactions: [] };
+    }
     res.json(data);
   } catch (err) {
     console.error('Error fetching transactions', err);

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -1,8 +1,12 @@
 const request = require('supertest');
+jest.mock('node-fetch', () => jest.fn());
+let fetch;
 
 // Reset modules before each test so env vars are re-evaluated
 beforeEach(() => {
   jest.resetModules();
+  fetch = require('node-fetch');
+  fetch.mockReset();
 });
 
 describe('API endpoints without token', () => {
@@ -20,5 +24,16 @@ describe('API endpoints without token', () => {
     const res = await request(app).get('/api/accounts/testuid/transactions');
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('STARLING_PERSONAL_TOKEN not set');
+  });
+});
+
+describe('transactions endpoint', () => {
+  test('returns empty transactions when Starling responds with empty body', async () => {
+    process.env.STARLING_PERSONAL_TOKEN = 'test-token';
+    fetch.mockResolvedValueOnce({ text: () => Promise.resolve('') });
+    const app = require('../index');
+    const res = await request(app).get('/api/accounts/acc123/transactions');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ transactions: [] });
   });
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,10 @@
         React.useEffect(() => {
           fetch(`/api/accounts/${account.accountUid || account.uid}/transactions`)
             .then(res => res.json())
-            .then(data => setTx(data.transactions || (data._embedded && data._embedded.transactions) || data))
+            .then(data => {
+              const txs = data.transactions || (data._embedded && data._embedded.transactions);
+              setTx(Array.isArray(txs) ? txs : []);
+            })
             .catch(err => console.error('Failed to fetch transactions', err));
         }, [account]);
 
@@ -48,7 +51,10 @@
         React.useEffect(() => {
           fetch('/api/accounts')
             .then(res => res.json())
-            .then(data => setAccounts(data.accounts || data))
+            .then(data => {
+              const accs = data.accounts;
+              setAccounts(Array.isArray(accs) ? accs : []);
+            })
             .catch(err => console.error('Failed to fetch accounts', err));
         }, []);
 


### PR DESCRIPTION
## Summary
- ensure transaction and account API results are arrays before rendering
- handle empty Starling transaction responses gracefully
- test transaction endpoint with empty response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad4160f188329ae22a269da67e748